### PR TITLE
Add options for UTF and Unicode properties

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,11 +26,13 @@ class PCREConan(ConanFile):
         "with_jit": [True, False],
         "build_pcrecpp": [True, False],
         "build_pcregrep": [True, False],
-        "with_utf": [True, False]
+        "with_utf": [True, False],
+        "with_unicode_properties": [True, False]
     }
     default_options = ("shared=False", "fPIC=True", "with_bzip2=True",
                        "with_zlib=True", "with_jit=False", "build_pcrecpp=False",
-                       "build_pcregrep=False", "with_utf=False")
+                       "build_pcregrep=False", "with_utf=False",
+                       "with_unicode_properties=False")
     source_subfolder = "source_subfolder"
     build_subfolder = "build_subfolder"
 
@@ -41,6 +43,8 @@ class PCREConan(ConanFile):
     def configure(self):
         if not self.options.build_pcrecpp:
             del self.settings.compiler.libcxx
+        if self.options.with_unicode_properties:
+            self.options.with_utf = True
 
     def patch_cmake(self):
         """Patch CMake file to avoid man and share during install stage
@@ -72,6 +76,7 @@ class PCREConan(ConanFile):
         cmake.definitions["PCRE_SUPPORT_LIBBZ2"] = self.options.with_bzip2
         cmake.definitions["PCRE_SUPPORT_JIT"] = self.options.with_jit
         cmake.definitions["PCRE_SUPPORT_UTF"] = self.options.with_utf
+        cmake.definitions["PCRE_SUPPORT_UNICODE_PROPERTIES"] = self.options.with_unicode_properties
         cmake.definitions["PCRE_SUPPORT_LIBREADLINE"] = False
         cmake.definitions["PCRE_SUPPORT_LIBEDIT"] = False
         if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,11 +25,12 @@ class PCREConan(ConanFile):
         "with_zlib": [True, False],
         "with_jit": [True, False],
         "build_pcrecpp": [True, False],
-        "build_pcregrep": [True, False]
+        "build_pcregrep": [True, False],
+        "with_utf": [True, False]
     }
     default_options = ("shared=False", "fPIC=True", "with_bzip2=True",
                        "with_zlib=True", "with_jit=False", "build_pcrecpp=False",
-                       "build_pcregrep=False")
+                       "build_pcregrep=False", "with_utf=False")
     source_subfolder = "source_subfolder"
     build_subfolder = "build_subfolder"
 
@@ -70,6 +71,7 @@ class PCREConan(ConanFile):
         cmake.definitions["PCRE_SUPPORT_LIBZ"] = self.options.with_zlib
         cmake.definitions["PCRE_SUPPORT_LIBBZ2"] = self.options.with_bzip2
         cmake.definitions["PCRE_SUPPORT_JIT"] = self.options.with_jit
+        cmake.definitions["PCRE_SUPPORT_UTF"] = self.options.with_utf
         cmake.definitions["PCRE_SUPPORT_LIBREADLINE"] = False
         cmake.definitions["PCRE_SUPPORT_LIBEDIT"] = False
         if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":


### PR DESCRIPTION
You could build PCRE as a test on the Mac by doing something like

```
conan create . kam/testing -o pcre:with_unicode_properties=True --build missing -pr apple-clang-9.1-macos-10.7
```

You can use a virtualenv from one of our projects to get `conan`.

Substitute your own username for `kam`.